### PR TITLE
add leave group

### DIFF
--- a/js/src/whalesong/chat.js
+++ b/js/src/whalesong/chat.js
@@ -195,7 +195,12 @@ export class ChatManager extends ModelManager {
 
   @command
   async leaveGroup() {
-    return await (this.model.sendExit() && this.model.sendDelete());
+    return await this.model.sendExit();
+  }
+
+  @command
+  async deleteChat() {
+    return await this.model.sendDelete();
   }
 
   @command

--- a/js/src/whalesong/chat.js
+++ b/js/src/whalesong/chat.js
@@ -194,6 +194,11 @@ export class ChatManager extends ModelManager {
   }
 
   @command
+  async leaveGroup() {
+    return await (this.model.sendExit() && this.model.sendDelete());
+  }
+
+  @command
   async sendSeen() {
     return await this.model.sendSeen();
   }

--- a/whalesong/managers/chat.py
+++ b/whalesong/managers/chat.py
@@ -109,6 +109,9 @@ class ChatManager(BaseModelManager):
     def leave_group(self):
         return self._execute_command('leaveGroup')
 
+    def delete_chat(self):
+        return self._execute_command('deleteChat')
+
     def send_seen(self):
         return self._execute_command('sendSeen')
 

--- a/whalesong/managers/chat.py
+++ b/whalesong/managers/chat.py
@@ -106,6 +106,9 @@ class ChatManager(BaseModelManager):
 
         return self._execute_command('sendMedia', params)
 
+    def leave_group(self):
+        return self._execute_command('leaveGroup')
+
     def send_seen(self):
         return self._execute_command('sendSeen')
 


### PR DESCRIPTION
Leave a chat group. I did not create a verification inside the method, is up to the person using the library to call the method ```leave_group``` only to a chat that it is a group.

If preferred, I can add the verification inside the method and throw an exception if the chat object is not a group chat.